### PR TITLE
Posts now display the time that they were created in a nice format

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,2 +1,6 @@
 class Post < ApplicationRecord
+
+  def self.format_time(time)
+    time.localtime.strftime('%d/%m/%Y %H:%M')
+  end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -5,7 +5,12 @@
 <% end %>
 
 <% @posts.each do |post| %>
-  <p><%= post.message %></p>
+  <div>
+    <p><%= post.message %> - 
+      <span> <%= Post.format_time(post.created_at) %> </span>
+    </p>
+  </div>
+
 <% end %>
 
 <%= link_to new_post_path do %>

--- a/spec/features/post_time_shown_spec.rb
+++ b/spec/features/post_time_shown_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.feature "Posts time shown", type: :feature do
+  scenario "All messages show time of creation" do
+    sign_up_helper('test@gmail.com', '123')
+    log_in_helper('test@gmail.com', '123')
+    click_link "New post"
+    fill_in "Message", with: "Hello, world!"
+    click_button "Submit"
+    expect(page.first(:css, "span").text).to match(/^([1-9]|([012][0-9])|(3[01]))\/([0]{0,1}[1-9]|1[012])\/\d\d\d\d\s([0-1]?[0-9]|2?[0-3]):([0-5]\d)$/)
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -2,4 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Post, type: :model do
   it { is_expected.to be }
+
+  it "converts a date from db into 'dd/mm/yyyy hh:mm' format" do
+    time = Time.new(2019, 04, 29, 2, 2, 2)
+    expect(Post.format_time(time)).to eq("29/04/2019 02:02")
+  end
 end


### PR DESCRIPTION
Created method in posts model to reformat time from database's default format.
Updated view to display post created time after individual posts.